### PR TITLE
feat(uniconfig-plugin-api-file): check error, use static import for fs

### DIFF
--- a/packages/uniconfig-plugin-api-file/package.json
+++ b/packages/uniconfig-plugin-api-file/package.json
@@ -6,7 +6,7 @@
   "types": "target/es5/index.d.ts",
   "scripts": {
     "clean": "rm -rf target",
-    "jest": "NODE_ENV=test BAZ=baz run -T jest -w 1 --config jest.config.json",
+    "jest": "NODE_ENV=test BAZ=baz jest -w 1 --config jest.config.json",
     "test": "yarn run jest",
     "build:es5": "mkdir -p target/es5 && run -T tsc -p tsconfig.build.json --target ES5 --outDir target/es5 -m CommonJS",
     "build:es6": "mkdir -p target/es6 && run -T tsc -p tsconfig.build.json --target ES6 --outDir target/es6",

--- a/packages/uniconfig-plugin-api-file/src/main/ts/index.ts
+++ b/packages/uniconfig-plugin-api-file/src/main/ts/index.ts
@@ -7,7 +7,7 @@ import {
 } from '@qiwi/uniconfig-core'
 
 export type IFsOpts = {
-  encoding: string,
+  encoding: BufferEncoding,
   flag?: string
 }
 
@@ -38,7 +38,7 @@ export const pipe: INamedPipe = {
       if (Array.isArray(target)) {
         for (const path of target) {
           try {
-            resolve(await require('fs/promises').readFile(path, processOpts(opts)))
+            resolve(await require('fs').promises.readFile(path, processOpts(opts)))
             return
           }
           catch (e) { /* noop */ }

--- a/packages/uniconfig-plugin-api-file/src/main/ts/index.ts
+++ b/packages/uniconfig-plugin-api-file/src/main/ts/index.ts
@@ -5,6 +5,7 @@ import {
   INamedPipe,
   IContext,
 } from '@qiwi/uniconfig-core'
+import {readFile, readFileSync, promises} from 'node:fs'
 
 export type IFsOpts = {
   encoding: BufferEncoding,
@@ -25,9 +26,13 @@ export const pipe: INamedPipe = {
     if (Array.isArray(target)) {
       for (const path of target) {
         try {
-          return require('fs').readFileSync(path, processOpts(opts))
+          return readFileSync(path, processOpts(opts))
         }
-        catch { /* noop */ }
+        catch (e: any) {
+          if (e.code !== 'ENOENT') {
+            throw e
+          }
+        }
       }
       throw new Error(`All targets are unreachable (${target})`)
     }
@@ -38,15 +43,19 @@ export const pipe: INamedPipe = {
       if (Array.isArray(target)) {
         for (const path of target) {
           try {
-            resolve(await require('fs').promises.readFile(path, processOpts(opts)))
+            resolve(await promises.readFile(path, processOpts(opts)))
             return
           }
-          catch (e) { /* noop */ }
+          catch (e: any) {
+            if (e.code !== 'ENOENT') {
+              throw e
+            }
+          }
         }
         reject(new Error(`All targets are unreachable (${target})`))
         return
       }
-      require('fs').readFile(target, processOpts(opts), (err: IAny | null, data: IAny) => {
+      readFile(target, processOpts(opts), (err: IAny | null, data: IAny) => {
         if (err) {
           reject(err)
         }


### PR DESCRIPTION
BREAKING CHANGE: fs is now required statically in uniconfig-plugin-api-file